### PR TITLE
Add SSL support

### DIFF
--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -31,3 +31,5 @@ jobs:
         run: make dialyzer
       - name: eunit
         run: make eunit
+      - name: ct
+        run: make ct

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ ok = rocketmq:stop_and_delete_supervised_producers(Producers),
 ok = rocketmq:stop_and_delete_supervised_client('client1').
 ```
 
+### SSL/TLS Connection
+
+See `test:start_tls()` example in `test/test.erl`.
+
 ## License
 
 Apache License Version 2.0

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,6 @@
-{deps, [{jsone, {git, "https://github.com/emqx/jsone", {tag, "1.7.1"}}}
+{deps, [
+        {jsone, {git, "https://github.com/emqx/jsone", {tag, "1.7.1"}}},
+        {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}}
        ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/src/rocketmq.app.src
+++ b/src/rocketmq.app.src
@@ -1,7 +1,7 @@
 {application,rocketmq,
              [{description,"A Erlang client library for Apache RocketMQ"},
-              {vsn,"0.5.3"},
+              {vsn,"0.5.4"},
               {modules,[]},
               {registered,[rocketmq_sup]},
-              {applications,[kernel,stdlib,jsone]},
+              {applications,[kernel,stdlib,jsone,ssl]},
               {mod,{rocketmq_app,[]}}]}.

--- a/src/rocketmq.app.src
+++ b/src/rocketmq.app.src
@@ -1,6 +1,6 @@
 {application,rocketmq,
              [{description,"A Erlang client library for Apache RocketMQ"},
-              {vsn,"0.5.4"},
+              {vsn,"0.6.0"},
               {modules,[]},
               {registered,[rocketmq_sup]},
               {applications,[kernel,stdlib,jsone,ssl]},

--- a/src/rocketmq.erl
+++ b/src/rocketmq.erl
@@ -35,6 +35,8 @@
         , batch_send_sync/3
         ]).
 
+-type time_ms() :: non_neg_integer().
+
 start() ->
     application:start(rocketmq).
 
@@ -64,7 +66,7 @@ send(Producers, {Message, Context}) when is_map(Context) ->
 
 -spec send_sync(rocketmq_producers:producers(),
                 binary() | {binary(), rocketmq_producers:produce_context()},
-                timer:time()) -> ok | {error, term()}.
+                time_ms()) -> ok | {error, term()}.
 send_sync(Producers, Message, Timeout) when is_binary(Message) ->
     send_sync(Producers, {Message, _Context = #{}}, Timeout);
 send_sync(Producers, {Message, Context}, Timeout) when is_map(Context) ->
@@ -74,7 +76,7 @@ send_sync(Producers, {Message, Context}, Timeout) when is_map(Context) ->
 
 -spec batch_send_sync(rocketmq_producers:producers(),
                 list(binary() | {binary(), rocketmq_producers:produce_context()}),
-                timer:time()) -> ok | {error, term()}.
+                time_ms()) -> ok | {error, term()}.
 batch_send_sync(Producers, Messages, Timeout) ->
     Context = fast_get_context(Messages),
     Messages2 = normalize_batch_messages(Messages),

--- a/src/rocketmq_client.erl
+++ b/src/rocketmq_client.erl
@@ -18,6 +18,8 @@
 
 -behaviour(gen_server).
 
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
 -export([start_link/3]).
 
 -export([get_routeinfo_by_topic/2]).
@@ -33,7 +35,8 @@
         , code_change/3
         ]).
 
--record(state, {requests, opaque_id, sock, sock_send_mod = gen_tcp, servers, opts, last_bin = <<>>}).
+-record(state, {requests, opaque_id, sock, sock_mod = gen_tcp, servers, opts, last_bin = <<>>}).
+
 
 -define(TIMEOUT, 60000).
 -define(T_GET_ROUTEINFO, 15000).
@@ -68,7 +71,7 @@ get_status(Pid) ->
 %%--------------------------------------------------------------------
 init([Servers, Opts]) ->
     State = #state{servers = Servers, opts = Opts},
-    SSLOpts = maps:get(ssl, Opts, undefined),
+    SSLOpts = maps:get(ssl_opts, Opts, undefined),
     SockSendMod = case SSLOpts of
                       undefined ->
                           gen_tcp;
@@ -79,7 +82,7 @@ init([Servers, Opts]) ->
         error ->
             {stop, fail_to_connect_rocketmq_server};
         Sock ->
-            {ok, State#state{sock = Sock, opaque_id = 1, requests = #{}, sock_send_mod = SockSendMod}}
+            {ok, State#state{sock = Sock, opaque_id = 1, requests = #{}, sock_mod = SockSendMod}}
     end.
 
 handle_call({get_routeinfo_by_topic, Topic}, From, State = #state{opaque_id = OpaqueId,
@@ -87,9 +90,9 @@ handle_call({get_routeinfo_by_topic, Topic}, From, State = #state{opaque_id = Op
                                                                   requests = Reqs,
                                                                   servers = Servers,
                                                                   opts = Opts,
-                                                                  sock_send_mod = SockSendMod
+                                                                  sock_mod = SockSendMod
                                                                   }) ->
-    case get_sock(Servers, Sock, maps:get(ssl, Opts, undefined)) of
+    case get_sock(Servers, Sock, maps:get(ssl_opts, Opts, undefined)) of
         error ->
             log(error, "Servers: ~p down", [Servers]),
             {noreply, State};
@@ -102,7 +105,7 @@ handle_call({get_routeinfo_by_topic, Topic}, From, State = #state{opaque_id = Op
     end;
 
 handle_call(get_status, _From, State = #state{sock = undefined, servers = Servers, opts = Opts}) ->
-    case get_sock(Servers, undefined, maps:get(ssl, Opts, undefined)) of
+    case get_sock(Servers, undefined, maps:get(ssl_opts, Opts, undefined)) of
         error -> {reply, false, State};
         Sock -> {reply, true, State#state{sock = Sock}}
     end;
@@ -115,10 +118,10 @@ handle_call(_Req, _From, State) ->
 handle_cast(_Req, State) ->
     {noreply, State, hibernate}.
 
-handle_info({tcp, _, Bin}, State) ->
+handle_info({tcp, Sock, Bin}, #state{sock = Sock} = State) ->
     handle_response(Bin, State);
 
-handle_info({ssl, _, Bin}, State) ->
+handle_info({ssl, Sock, Bin}, #state{sock = Sock} = State) ->
     handle_response(Bin, State);
 
 handle_info({tcp_closed, Sock}, State = #state{sock = Sock}) ->
@@ -128,6 +131,7 @@ handle_info({ssl_closed, Sock}, State = #state{sock = Sock}) ->
     {noreply, State#state{sock = undefined}, hibernate};
 
 handle_info({ssl_error, Sock, Reason}, State = #state{sock = Sock}) ->
+    _ = ssl:close(Sock),
     log(error, "RocketMQ client Received SSL socket error: ~p~n", [Reason]),
     {noreply, State#state{sock = undefined}, hibernate};
 
@@ -181,21 +185,26 @@ try_connect([{Host, Port} | Servers], SSLOpts) ->
         {ok, Sock} ->
             tune_buffer(Sock),
             gen_tcp:controlling_process(Sock, self()),
-            case maybe_get_tls_sock(Sock, SSLOpts) of
-                {error, _} ->
+            case maybe_upgrade_tls(Sock, SSLOpts) of
+                {error, TLSConnectErrorReason} ->
+                    log(warning, "Could not establish TLS connection ~p:~p, Reason: ~p",
+                        [Host, Port, TLSConnectErrorReason]),
                     try_connect(Servers, SSLOpts);
                 TLSSock ->
                     TLSSock
             end;
-        _Error ->
+        {error, TCPConnectErrorReason} ->
+            log(warning, "Could not establish TCP connection ~p:~p, Reason: ~p",
+                [Host, Port, TCPConnectErrorReason]),
             try_connect(Servers, SSLOpts)
     end.
 
-maybe_get_tls_sock(Sock, undefined) ->
+maybe_upgrade_tls(Sock, undefined) ->
     Sock;
-maybe_get_tls_sock(Sock, SSLOpts) ->
+maybe_upgrade_tls(Sock, SSLOpts) ->
     case ssl:connect(Sock, SSLOpts, ?TIMEOUT) of
         {ok, Sock1} ->
+            ?tp(rocketmq_client_got_tls_sock, #{}),
             Sock1;
         Error ->
             Error

--- a/src/rocketmq_producer.erl
+++ b/src/rocketmq_producer.erl
@@ -53,9 +53,12 @@ callback_mode() -> [state_functions].
                 topic,
                 server,
                 sock,
+                client_id = undefined,
+                send_sock_mod = gen_tcp,
                 queue_id,
                 opaque_id = 1,
                 opts = [],
+                ssl_opts = undefined,
                 callback,
                 batch_size = 0,
                 requests = #{},
@@ -85,6 +88,7 @@ batch_send_sync(Pid, Messages, Timeout) ->
 %% gen_server callback
 %%--------------------------------------------------------------------
 init([QueueId, Topic, Server, ProducerGroup, ProducerOpts]) ->
+    SSLOpts = maps:get(ssl, ProducerOpts, undefined),
     State = #state{producer_group = ProducerGroup,
                    topic = Topic,
                    queue_id = QueueId,
@@ -92,19 +96,30 @@ init([QueueId, Topic, Server, ProducerGroup, ProducerOpts]) ->
                    batch_size = maps:get(batch_size, ProducerOpts, 0),
                    server = Server,
                    opts = maps:get(tcp_opts, ProducerOpts, []),
+                   ssl_opts = SSLOpts,
+                   send_sock_mod = case SSLOpts of
+                                       undefined -> gen_tcp;
+                                       _ -> ssl
+                                   end,
                    producer_opts = ProducerOpts
                    },
     self() ! connecting,
     {ok, idle, State}.
 
-idle(_, connecting, State = #state{opts = Opts, server = Server}) ->
+idle(_, connecting, State = #state{opts = Opts, ssl_opts = SSLOpts, server = Server}) ->
     {Host, Port} = parse_url(Server),
     case gen_tcp:connect(Host, Port, merge_opts(Opts, ?TCPOPTIONS), ?TIMEOUT) of
         {ok, Sock} ->
             tune_buffer(Sock),
             gen_tcp:controlling_process(Sock, self()),
             start_keepalive(),
-            {next_state, connected, State#state{sock = Sock}};
+            ClientID = client_id(Sock),
+            case maybe_get_tls_sock(Sock, SSLOpts) of
+                {error, SSLError} ->
+                    {stop, {shutdown, SSLError}, State};
+                Sock1 ->
+                    {next_state, connected, State#state{sock = Sock1, client_id = ClientID}}
+            end;
         Error ->
             {stop, {shutdown, Error}, State}
     end;
@@ -112,12 +127,35 @@ idle(_, connecting, State = #state{opts = Opts, server = Server}) ->
 idle(_, ping, State = #state{sock = undefined}) ->
     {keep_state, State}.
 
+maybe_get_tls_sock(Sock, undefined) ->
+    Sock;
+maybe_get_tls_sock(Sock, SSLOpts) ->
+    case ssl:connect(Sock, SSLOpts, ?TIMEOUT) of
+        {ok, Sock1} ->
+            Sock1;
+        Error ->
+            Error
+    end.
+
 connected(_EventType, {tcp_closed, Sock}, State = #state{sock = Sock}) ->
     log_error("TcpClosed producer: ~p~n", [self()]),
     erlang:send_after(5000, self(), connecting),
     {next_state, idle, State#state{sock = undefined}};
 
+connected(_EventType, {ssl_closed, Sock}, State = #state{sock = Sock}) ->
+    log_error("SSLClosed producer: ~p~n", [self()]),
+    erlang:send_after(5000, self(), connecting),
+    {next_state, idle, State#state{sock = undefined}};
+
+connected(_EventType, {ssl_error, Sock, Reason}, State = #state{sock = Sock}) ->
+    log_error("SSL Socket Error, producer: ~p, reason: ~p~n", [self(), Reason]),
+    erlang:send_after(5000, self(), connecting),
+    {next_state, idle, State#state{sock = undefined}};
+
 connected(_EventType, {tcp, _, Bin}, State) ->
+    handle_response(Bin, State);
+
+connected(_EventType, {ssl, _, Bin}, State) ->
     handle_response(Bin, State);
 
 connected({call, From}, {send, MsgAndProps}, State = #state{sock = Sock,
@@ -126,9 +164,10 @@ connected({call, From}, {send, MsgAndProps}, State = #state{sock = Sock,
                                                         producer_group = ProducerGroup,
                                                         opaque_id = Opaque,
                                                         requests = Reqs,
-                                                        producer_opts = ProducerOpts
+                                                        producer_opts = ProducerOpts,
+                                                        send_sock_mod = SendSockMod
                                                         }) ->
-    send(Sock, ProducerGroup, get_namespace(ProducerOpts), Topic, Opaque, QueueId, MsgAndProps, get_acl_info(ProducerOpts)),
+    send(Sock, ProducerGroup, get_namespace(ProducerOpts), Topic, Opaque, QueueId, MsgAndProps, get_acl_info(ProducerOpts), SendSockMod),
     {keep_state, next_opaque_id(State#state{requests = maps:put(Opaque, From, Reqs)})};
 
 connected({call, From}, {batch_send, Messages}, State = #state{sock = Sock,
@@ -137,9 +176,10 @@ connected({call, From}, {batch_send, Messages}, State = #state{sock = Sock,
                                                         producer_group = ProducerGroup,
                                                         opaque_id = Opaque,
                                                         requests = Reqs,
-                                                        producer_opts = ProducerOpts
+                                                        producer_opts = ProducerOpts,
+                                                        send_sock_mod = SendSockMod
                                                         }) ->
-    batch_send(Sock, ProducerGroup, get_namespace(ProducerOpts), Topic, Opaque, QueueId, Messages, get_acl_info(ProducerOpts)),
+    batch_send(Sock, ProducerGroup, get_namespace(ProducerOpts), Topic, Opaque, QueueId, Messages, get_acl_info(ProducerOpts), SendSockMod),
     {keep_state, next_opaque_id(State#state{requests = maps:put(Opaque, From, Reqs)})};
 
 connected(cast, {send, MsgAndProps}, State = #state{sock = Sock,
@@ -149,16 +189,17 @@ connected(cast, {send, MsgAndProps}, State = #state{sock = Sock,
                                                 opaque_id = Opaque,
                                                 batch_size = BatchSize,
                                                 producer_opts = ProducerOpts,
-                                                requests = Requests
+                                                requests = Requests,
+                                                send_sock_mod = SendSockMod
                                                 }) ->
     BatchLen =
         case BatchSize =< 1 of
             true ->
-                _ = send(Sock, ProducerGroup, get_namespace(ProducerOpts), Topic, Opaque, QueueId, MsgAndProps, get_acl_info(ProducerOpts)),
+                _ = send(Sock, ProducerGroup, get_namespace(ProducerOpts), Topic, Opaque, QueueId, MsgAndProps, get_acl_info(ProducerOpts), SendSockMod),
                 1;
             false ->
                 MsgPropsList = [MsgAndProps | collect_send_calls(BatchSize)],
-                _ = batch_send(Sock, ProducerGroup, get_namespace(ProducerOpts), Topic, Opaque, QueueId, MsgPropsList, get_acl_info(ProducerOpts)),
+                _ = batch_send(Sock, ProducerGroup, get_namespace(ProducerOpts), Topic, Opaque, QueueId, MsgPropsList, get_acl_info(ProducerOpts), SendSockMod),
                 erlang:length(MsgPropsList)
         end,
     NRequests = maps:put(Opaque, {batch_len, BatchLen}, Requests),
@@ -168,8 +209,10 @@ connected(cast, {send, MsgAndProps}, State = #state{sock = Sock,
 connected(_EventType, ping, State = #state{sock = Sock,
                                            producer_group = ProducerGroup,
                                            opaque_id = Opaque,
-                                           producer_opts = ProducerOpts}) ->
-    ping(Sock, ProducerGroup, Opaque, get_acl_info(ProducerOpts)),
+                                           producer_opts = ProducerOpts,
+                                           send_sock_mod = SendSockMod,
+                                           client_id = ClientID}) ->
+    ping(Sock, ProducerGroup, Opaque, get_acl_info(ProducerOpts), SendSockMod, ClientID),
     {keep_state, next_opaque_id(State)};
 
 connected(_EventType, EventContent, State) ->
@@ -233,21 +276,23 @@ result(Header) ->
 start_keepalive() ->
     erlang:send_after(30*1000, self(), ping).
 
-ping(Sock, ProducerGroup, Opaque, ACLInfo) ->
-    {ok, {Host, Port}} = inet:sockname(Sock),
-    Host1 = inet_parse:ntoa(Host),
-    ClientId = list_to_binary(lists:concat([Host1, "@", Port])),
+ping(Sock, ProducerGroup, Opaque, ACLInfo, SendSockMod, ClientId) ->
     Package = rocketmq_protocol_frame:heart_beat(Opaque, ClientId, ProducerGroup, ACLInfo),
-    gen_tcp:send(Sock, Package),
+    SendSockMod:send(Sock, Package),
     start_keepalive().
 
-send(Sock, ProducerGroup, Namespace, Topic, Opaque, QueueId, MsgAndProps, ACLInfo) ->
-    Package = rocketmq_protocol_frame:send_message_v2(Opaque, ProducerGroup, Namespace, Topic, QueueId, MsgAndProps, ACLInfo),
-    gen_tcp:send(Sock, Package).
+client_id(Sock) ->
+    {ok, {Host, Port}} = inet:sockname(Sock),
+    Host1 = inet_parse:ntoa(Host),
+    list_to_binary(lists:concat([Host1, "@", Port])).
 
-batch_send(Sock, ProducerGroup, Namespace, Topic, Opaque, QueueId, MsgAndPropsList, ACLInfo) ->
+send(Sock, ProducerGroup, Namespace, Topic, Opaque, QueueId, MsgAndProps, ACLInfo, SendSockMod) ->
+    Package = rocketmq_protocol_frame:send_message_v2(Opaque, ProducerGroup, Namespace, Topic, QueueId, MsgAndProps, ACLInfo),
+    SendSockMod:send(Sock, Package).
+
+batch_send(Sock, ProducerGroup, Namespace, Topic, Opaque, QueueId, MsgAndPropsList, ACLInfo, SendSockMod) ->
     Package = rocketmq_protocol_frame:send_batch_message_v2(Opaque, ProducerGroup, Namespace, Topic, QueueId, MsgAndPropsList, ACLInfo),
-    gen_tcp:send(Sock, Package).
+    SendSockMod:send(Sock, Package).
 
 
 collect_send_calls(0) ->

--- a/test/basic_tests_SUITE.erl
+++ b/test/basic_tests_SUITE.erl
@@ -2,13 +2,20 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 
 -export([all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
--export([basic_test/1, basic_test_tls/1]).
+-export([
+         basic_test/1,
+         basic_test_tls/1
+        ]).
 
 all() ->
-    [basic_test, basic_test_tls].
+    [
+     basic_test,
+     basic_test_tls
+    ].
 
 init_per_suite(Config) ->
     Config.
@@ -22,10 +29,19 @@ init_per_testcase(_TestCase, Config) ->
 end_per_testcase(_TestCase, _Config) ->
     ok.
 
-basic_test(Config) ->
+basic_test(_Config) ->
     ?assertEqual(ok, test:start()),
-    Config.
+    ok.
 
-basic_test_tls(Config) ->
-    ?assertEqual(ok, test:start_tls()),
-    Config.
+basic_test_tls(_Config) ->
+     ?check_trace(
+         %% Run stage:
+         begin
+           test:start_tls()
+         end,
+         %% Check stage:
+         fun(RunStageResult, Trace) ->
+             ?assertMatch(ok, RunStageResult),
+             ?assertMatch([_|_], ?of_kind(rocketmq_client_got_tls_sock, Trace)),
+             ?assertMatch([_|_], ?of_kind(rocketmq_producer_got_tls_sock, Trace))
+         end).

--- a/test/basic_tests_SUITE.erl
+++ b/test/basic_tests_SUITE.erl
@@ -1,0 +1,31 @@
+-module(basic_tests_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+
+-export([all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
+-export([basic_test/1, basic_test_tls/1]).
+
+all() ->
+    [basic_test, basic_test_tls].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
+basic_test(Config) ->
+    ?assertEqual(ok, test:start()),
+    Config.
+
+basic_test_tls(Config) ->
+    ?assertEqual(ok, test:start_tls()),
+    Config.

--- a/test/test.erl
+++ b/test/test.erl
@@ -1,6 +1,6 @@
 -module(test).
 
--export([start/0, callback/3]).
+-export([start/0, start_tls/0, callback/3]).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -29,6 +29,42 @@ start() ->
         rocketmq:ensure_supervised_producers(Clientid, ProducerGroup, Topic, ProducerOpts),
     io:format("start producer ~p~n", [Producers]),
     % SSendRes = rocketmq:send_sync(Producers, <<"hello, form sdk">>, 1000),
+    SSendRes = ok = rocketmq:send(Producers, <<"hello, form sdk">>),
+    io:format("send async ~p~n", [SSendRes]),
+    SSendRes2 = ok = rocketmq:send(Producers, <<"hello, form sdk">>),
+    io:format("send2 async ~p~n", [SSendRes2]),
+
+    ok = rocketmq:batch_send_sync(Producers, [<<"hello">>, <<"form">>, <<"sdk">>], 10000),
+    ok.
+
+%% RocketMQ listen to both TLS traffic and unencrypted traffic on the same port
+%% by default (https://github.com/apache/rocketmq/wiki/How-to-Configure-TLS) so
+%% we can use the same docker-compose file for testing both unencrypted and TLS
+%% connections. Please notice that we need to configure ssl both for the client
+%% and the producer if both the name sever and the brokers use SSL.
+start_tls() ->
+    application:ensure_all_started(rocketmq),
+    Clientid = 'test-client',
+    Servers = [{"127.0.0.1", 9876}],
+    AclInfo = #{access_key => <<"RocketMQ">>, secret_key => <<"12345678">>},
+    ClientCfg = #{acl_info => AclInfo, ssl => [{verify, verify_none}]},
+    {ok, Pid} = rocketmq:ensure_supervised_client(Clientid, Servers, ClientCfg),
+    io:format("start client ~p~n", [Pid]),
+    Topic = <<"test-topic">>,
+    ProducerGroup = list_to_binary(lists:concat([Clientid, "_", binary_to_list(Topic)])),
+
+    ProducerOpts =
+        #{batch_size => 100,
+          callback => {?MODULE, callback, []},
+          name => producer_t1,
+          ref_topic_route_interval => 3000,
+          tcp_opts => [{sndbuf, 1048576}],
+          ssl => [{verify, verify_none}],
+          acl_info => AclInfo},
+    {ok, Producers} =
+        rocketmq:ensure_supervised_producers(Clientid, ProducerGroup, Topic, ProducerOpts),
+    io:format("start producer ~p~n", [Producers]),
+    % SSendRes = rocketmq:send_sync(Producers, <<"hello, form sdk">>, 1000),
     SSendRes = rocketmq:send(Producers, <<"hello, form sdk">>),
     io:format("send async ~p~n", [SSendRes]),
     SSendRes2 = rocketmq:send(Producers, <<"hello, form sdk">>),
@@ -38,4 +74,7 @@ start() ->
     ok.
 
 callback(Code, Topic, Size) ->
+    ok = Code,
+    <<"test-topic">> = Topic,
+    1 = Size,
     io:format("callback Code: ~p Topic: ~p Size: ~p~n", [Code, Topic, Size]).

--- a/test/test.erl
+++ b/test/test.erl
@@ -44,10 +44,10 @@ start() ->
 %% and the producer if both the name sever and the brokers use SSL.
 start_tls() ->
     application:ensure_all_started(rocketmq),
-    Clientid = 'test-client',
+    Clientid = 'test-client-ssl',
     Servers = [{"127.0.0.1", 9876}],
     AclInfo = #{access_key => <<"RocketMQ">>, secret_key => <<"12345678">>},
-    ClientCfg = #{acl_info => AclInfo, ssl => [{verify, verify_none}]},
+    ClientCfg = #{acl_info => AclInfo, ssl_opts => [{verify, verify_none}]},
     {ok, Pid} = rocketmq:ensure_supervised_client(Clientid, Servers, ClientCfg),
     io:format("start client ~p~n", [Pid]),
     Topic = <<"test-topic">>,
@@ -56,10 +56,10 @@ start_tls() ->
     ProducerOpts =
         #{batch_size => 100,
           callback => {?MODULE, callback, []},
-          name => producer_t1,
+          name => producer_t1_ssl,
           ref_topic_route_interval => 3000,
           tcp_opts => [{sndbuf, 1048576}],
-          ssl => [{verify, verify_none}],
+          ssl_opts => [{verify, verify_none}],
           acl_info => AclInfo},
     {ok, Producers} =
         rocketmq:ensure_supervised_producers(Clientid, ProducerGroup, Topic, ProducerOpts),


### PR DESCRIPTION
This PR adds SSL/TLS support to the RocketMQ library. This will make it possible to connect to RocketMQ with encrypted connections.