### PR TITLE
fix: do not block supervisor during client init

### DIFF
--- a/src/rocketmq_client.erl
+++ b/src/rocketmq_client.erl
@@ -40,6 +40,7 @@
 
 
 -define(TIMEOUT, 60000).
+-define(CONNECT_TIMEOUT, 10000).
 -define(T_GET_ROUTEINFO, 15000).
 
 -define(TCPOPTIONS, [
@@ -204,7 +205,7 @@ get_sock(_Servers, Sock, _SSLOpts) ->
 try_connect([], _SSLOpts) ->
     error;
 try_connect([{Host, Port} | Servers], SSLOpts) ->
-    case gen_tcp:connect(Host, Port, ?TCPOPTIONS, ?TIMEOUT) of
+    case gen_tcp:connect(Host, Port, ?TCPOPTIONS, ?CONNECT_TIMEOUT) of
         {ok, Sock} ->
             tune_buffer(Sock),
             gen_tcp:controlling_process(Sock, self()),
@@ -225,7 +226,7 @@ try_connect([{Host, Port} | Servers], SSLOpts) ->
 maybe_upgrade_tls(Sock, undefined) ->
     Sock;
 maybe_upgrade_tls(Sock, SSLOpts) ->
-    case ssl:connect(Sock, SSLOpts, ?TIMEOUT) of
+    case ssl:connect(Sock, SSLOpts, ?CONNECT_TIMEOUT) of
         {ok, Sock1} ->
             ?tp(rocketmq_client_got_tls_sock, #{}),
             Sock1;

--- a/src/rocketmq_client.erl
+++ b/src/rocketmq_client.erl
@@ -97,8 +97,7 @@ init([Servers, Opts]) ->
 handle_continue(connect, State = #state{sock = undefined,
                                         servers = Servers,
                                         opts = Opts}) ->
-    SSLOpts = maps:get(ssl_opts, Opts, undefined),
-    case get_sock(Servers, undefined, SSLOpts) of
+    case get_sock(Servers, undefined, Opts) of
         error ->
             %% Leave sock = undefined; subsequent get_status /
             %% get_routeinfo_by_topic calls will retry the connect.
@@ -116,7 +115,7 @@ handle_call({get_routeinfo_by_topic, Topic}, From, State = #state{opaque_id = Op
                                                                   opts = Opts,
                                                                   sock_mod = SockSendMod
                                                                   }) ->
-    case get_sock(Servers, Sock, maps:get(ssl_opts, Opts, undefined)) of
+    case get_sock(Servers, Sock, Opts) of
         error ->
             log(error, "Servers: ~p down", [Servers]),
             {noreply, State};
@@ -129,7 +128,7 @@ handle_call({get_routeinfo_by_topic, Topic}, From, State = #state{opaque_id = Op
     end;
 
 handle_call(get_status, _From, State = #state{sock = undefined, servers = Servers, opts = Opts}) ->
-    case get_sock(Servers, undefined, maps:get(ssl_opts, Opts, undefined)) of
+    case get_sock(Servers, undefined, Opts) of
         error -> {reply, false, State};
         Sock -> {reply, true, State#state{sock = Sock}}
     end;
@@ -197,36 +196,38 @@ tune_buffer(Sock) ->
         = inet:getopts(Sock, [recbuf, sndbuf]),
     inet:setopts(Sock, [{buffer, max(RecBuf, SndBuf)}]).
 
-get_sock(Servers, undefined, SSLOpts) ->
-    try_connect(Servers, SSLOpts);
-get_sock(_Servers, Sock, _SSLOpts) ->
+get_sock(Servers, undefined, Opts) ->
+    SSLOpts = maps:get(ssl_opts, Opts, undefined),
+    ConnectTimeout = maps:get(connect_timeout, Opts, ?CONNECT_TIMEOUT),
+    try_connect(Servers, SSLOpts, ConnectTimeout);
+get_sock(_Servers, Sock, _Opts) ->
     Sock.
 
-try_connect([], _SSLOpts) ->
+try_connect([], _SSLOpts, _ConnectTimeout) ->
     error;
-try_connect([{Host, Port} | Servers], SSLOpts) ->
-    case gen_tcp:connect(Host, Port, ?TCPOPTIONS, ?CONNECT_TIMEOUT) of
+try_connect([{Host, Port} | Servers], SSLOpts, ConnectTimeout) ->
+    case gen_tcp:connect(Host, Port, ?TCPOPTIONS, ConnectTimeout) of
         {ok, Sock} ->
             tune_buffer(Sock),
             gen_tcp:controlling_process(Sock, self()),
-            case maybe_upgrade_tls(Sock, SSLOpts) of
+            case maybe_upgrade_tls(Sock, SSLOpts, ConnectTimeout) of
                 {error, TLSConnectErrorReason} ->
                     log(warning, "Could not establish TLS connection ~p:~p, Reason: ~p",
                         [Host, Port, TLSConnectErrorReason]),
-                    try_connect(Servers, SSLOpts);
+                    try_connect(Servers, SSLOpts, ConnectTimeout);
                 TLSSock ->
                     TLSSock
             end;
         {error, TCPConnectErrorReason} ->
             log(warning, "Could not establish TCP connection ~p:~p, Reason: ~p",
                 [Host, Port, TCPConnectErrorReason]),
-            try_connect(Servers, SSLOpts)
+            try_connect(Servers, SSLOpts, ConnectTimeout)
     end.
 
-maybe_upgrade_tls(Sock, undefined) ->
+maybe_upgrade_tls(Sock, undefined, _ConnectTimeout) ->
     Sock;
-maybe_upgrade_tls(Sock, SSLOpts) ->
-    case ssl:connect(Sock, SSLOpts, ?CONNECT_TIMEOUT) of
+maybe_upgrade_tls(Sock, SSLOpts, ConnectTimeout) ->
+    case ssl:connect(Sock, SSLOpts, ConnectTimeout) of
         {ok, Sock1} ->
             ?tp(rocketmq_client_got_tls_sock, #{}),
             Sock1;

--- a/src/rocketmq_client.erl
+++ b/src/rocketmq_client.erl
@@ -30,6 +30,7 @@
 -export([ init/1
         , handle_call/3
         , handle_cast/2
+        , handle_continue/2
         , handle_info/2
         , terminate/2
         , code_change/3
@@ -70,7 +71,6 @@ get_status(Pid) ->
 %% gen_server callback
 %%--------------------------------------------------------------------
 init([Servers, Opts]) ->
-    State = #state{servers = Servers, opts = Opts},
     SSLOpts = maps:get(ssl_opts, Opts, undefined),
     SockSendMod = case SSLOpts of
                       undefined ->
@@ -78,12 +78,35 @@ init([Servers, Opts]) ->
                       _ ->
                           ssl
                   end,
+    %% Do not perform the initial TCP/TLS connect in init/1.
+    %% The supervisor is blocked while init runs, so a slow/unreachable
+    %% server would stall every other rocketmq client sharing the
+    %% singleton rocketmq_client_sup. Kick off the connect asynchronously
+    %% via handle_continue/2 instead; sock stays undefined until ready.
+    State = #state{
+        servers = Servers,
+        opts = Opts,
+        sock = undefined,
+        opaque_id = 1,
+        requests = #{},
+        sock_mod = SockSendMod
+    },
+    {ok, State, {continue, connect}}.
+
+handle_continue(connect, State = #state{sock = undefined,
+                                        servers = Servers,
+                                        opts = Opts}) ->
+    SSLOpts = maps:get(ssl_opts, Opts, undefined),
     case get_sock(Servers, undefined, SSLOpts) of
         error ->
-            {stop, fail_to_connect_rocketmq_server};
+            %% Leave sock = undefined; subsequent get_status /
+            %% get_routeinfo_by_topic calls will retry the connect.
+            {noreply, State};
         Sock ->
-            {ok, State#state{sock = Sock, opaque_id = 1, requests = #{}, sock_mod = SockSendMod}}
-    end.
+            {noreply, State#state{sock = Sock}}
+    end;
+handle_continue(_, State) ->
+    {noreply, State}.
 
 handle_call({get_routeinfo_by_topic, Topic}, From, State = #state{opaque_id = OpaqueId,
                                                                   sock = Sock,


### PR DESCRIPTION
## Summary

`rocketmq_client_sup` is a singleton shared by every connector in the host application (e.g. EMQX RocketMQ bridge). `rocketmq_client:init/1` previously called `gen_tcp:connect` synchronously with a 60 s timeout, which holds the supervisor's `start_child` reply for the full duration. While that call is in flight, every other client's `start_child` / `terminate_child` / `which_children` serializes behind it — so a single misconfigured broker (unreachable IP) stalls health checks and operations on every other client sharing the sup.

This PR moves the initial connect off the supervisor's critical path by using `handle_continue/2`:

- `init/1` returns immediately with `sock = undefined`.
- `handle_continue(connect, State)` performs the TCP/TLS connect.
- On failure, `sock` stays `undefined` and is retried by the existing `get_status` / `get_routeinfo_by_topic` paths.

## Why this matters

Reproduced on EMQX 5.10.3 with one healthy connector ("good") and one connector pointing at an unroutable IP ("bad"). Before this change, the good connector's health check flipped to `disconnected — resource_health_check_timed_out`, and operator API calls (PUT to disable) blocked ~60 s behind the bad connector's `init/1`. After this change the good connector stays `connected` steadily and API ops on it complete in a few seconds.

No `rocketmq_client:init/1` crash reports with `fail_to_connect_rocketmq_server`, no `{badmatch,{error,not_found}}` fallout from the resource manager's cleanup path, and no spillover health-check timeouts on sibling clients.

## Test plan

- [x] Local reproduction with EMQX 5.10.3 + two RocketMQ connectors (one valid, one unreachable). Good connector stable over 2 min; operator API on good completes quickly; zero init crashes post-fix.
- [x] Run the existing `basic_tests_SUITE` and bridge test suite in CI.