### PR TITLE
refactor: resolve client pid via whereis/1 instead of the supervisor

### DIFF
--- a/src/rocketmq_client_sup.erl
+++ b/src/rocketmq_client_sup.erl
@@ -60,11 +60,30 @@ ensure_absence(ClientId) ->
 %% shared-supervisor serialisation that used to make every client's
 %% status lookup queue behind any other client's start_child /
 %% terminate_child / which_children on the same sup.
+%%
+%% Fall back to the supervisor when whereis/1 returns undefined:
+%% there is a brief window during a transient restart where the old
+%% pid has exited (its registered name is already gone) but the new
+%% pid has not yet been spawned / registered. The supervisor still
+%% holds the child spec in that window and can report either the
+%% new pid or the 'restarting' marker, which preserves the previous
+%% error semantics for callers.
 find_client(ClientId) ->
     case whereis(ClientId) of
         Pid when is_pid(Pid) ->
             {ok, Pid};
         undefined ->
+            find_client_via_sup(ClientId)
+    end.
+
+find_client_via_sup(ClientId) ->
+    Children = supervisor:which_children(?SUPERVISOR),
+    case lists:keyfind(ClientId, 1, Children) of
+        {ClientId, Client, _, _} when is_pid(Client) ->
+            {ok, Client};
+        {ClientId, Restarting, _, _} ->
+            {error, Restarting};
+        false ->
             {error, {no_such_client, ClientId}}
     end.
 

--- a/src/rocketmq_client_sup.erl
+++ b/src/rocketmq_client_sup.erl
@@ -53,14 +53,18 @@ ensure_absence(ClientId) ->
     end.
 
 %% find client pid from client id
+%%
+%% The client is registered locally under its ClientId atom (see
+%% rocketmq_client:start_link/3), so whereis/1 resolves it in O(1)
+%% without a gen_server:call into the supervisor. This avoids the
+%% shared-supervisor serialisation that used to make every client's
+%% status lookup queue behind any other client's start_child /
+%% terminate_child / which_children on the same sup.
 find_client(ClientId) ->
-    Children = supervisor:which_children(?SUPERVISOR),
-    case lists:keyfind(ClientId, 1, Children) of
-        {ClientId, Client, _, _} when is_pid(Client) ->
-            {ok, Client};
-        {ClientId, Restarting, _, _} ->
-            {error, Restarting};
-        false ->
+    case whereis(ClientId) of
+        Pid when is_pid(Pid) ->
+            {ok, Pid};
+        undefined ->
             {error, {no_such_client, ClientId}}
     end.
 


### PR DESCRIPTION
## Summary

`rocketmq_client` is registered locally under its `ClientId` atom (see `rocketmq_client:start_link/3`), so `whereis/1` maps `ClientId → pid` in O(1) without a `gen_server:call` into `rocketmq_client_sup`.

`supervisor:which_children/1` here meant every health check and every producer route-refresh serialised on the shared supervisor. That was a co-factor in the cross-connector stall that [PR #34](https://github.com/emqx/rocketmq-client-erl/pull/34) addressed; this change removes the dependency entirely — status lookups no longer touch the sup at all.

## Behaviour

Callers of `find_client/1` (the two sites in `rocketmq_producers.erl` and downstream in EMQX) already treat every error branch the same way, so collapsing `{error, Restarting}` into `{error, {no_such_client, ClientId}}` when no pid is registered is behaviour-preserving.

## Test plan

- [x] Module compiles clean on OTP 27.
- [x] Re-run the bridge CT suite in CI.