### PR TITLE
feat: record last error and drive async reconnect from get_connection_state

### DIFF
--- a/src/rocketmq_client.erl
+++ b/src/rocketmq_client.erl
@@ -57,7 +57,11 @@
     %% True while an async try_reconnect is in flight, to avoid
     %% queueing multiple reconnect attempts when health checks arrive
     %% faster than a connect attempt can complete.
-    reconnecting = false
+    reconnecting = false,
+    %% Opt-in free-form field reserved for hot upgrades so the record
+    %% layout can be frozen across versions without appending new
+    %% fields.
+    extra = #{} :: map()
 }).
 
 
@@ -306,7 +310,7 @@ kick_async_reconnect(State) ->
 get_sock(Servers, undefined, Opts) ->
     SSLOpts = maps:get(ssl_opts, Opts, undefined),
     ConnectTimeout = maps:get(connect_timeout, Opts, ?CONNECT_TIMEOUT),
-    try_connect(Servers, SSLOpts, ConnectTimeout, no_error);
+    try_connect(Servers, SSLOpts, ConnectTimeout, no_servers);
 get_sock(_Servers, Sock, _Opts) ->
     {ok, Sock}.
 

--- a/src/rocketmq_client.erl
+++ b/src/rocketmq_client.erl
@@ -36,13 +36,29 @@
         , code_change/3
         ]).
 
--record(state, {requests, opaque_id, sock, sock_mod = gen_tcp, servers, opts, last_bin = <<>>,
-                %% Number of consecutive failed connect attempts since the
-                %% last successful connect. Stays at 0 while the socket is
-                %% up; resets to 0 on every successful get_sock. Used to
-                %% distinguish a transient disconnect (just dropped, not
-                %% yet retried) from a persistent failure.
-                reconnect_attempts = 0}).
+-record(state, {
+    requests,
+    opaque_id,
+    sock,
+    sock_mod = gen_tcp,
+    servers,
+    opts,
+    last_bin = <<>>,
+    %% Number of consecutive failed connect attempts since the last
+    %% successful connect. Stays at 0 while the socket is up; resets
+    %% to 0 on every successful get_sock. Used to distinguish a
+    %% transient disconnect (just dropped, not yet retried) from a
+    %% persistent failure.
+    reconnect_attempts = 0,
+    %% Last connect / socket failure reason since the last successful
+    %% connect. `undefined' when the socket is healthy or has never
+    %% failed. Cleared on successful connect.
+    last_error = undefined,
+    %% True while an async try_reconnect is in flight, to avoid
+    %% queueing multiple reconnect attempts when health checks arrive
+    %% faster than a connect attempt can complete.
+    reconnecting = false
+}).
 
 
 -define(TIMEOUT, 60000).
@@ -74,12 +90,22 @@ get_routeinfo_by_topic(Pid, Topic) ->
 get_status(Pid) ->
     gen_server:call(Pid, get_status, 5000).
 
-%% Reports connection state without side-effects:
-%%   connected    -- socket is currently up (reconnect_attempts = 0)
-%%   connecting   -- socket down, no failed retry yet (reconnect_attempts = 0)
-%%   disconnected -- one or more failed connect attempts since last success
+%% Reports connection state without blocking on a connect attempt, and
+%% kicks off an async reconnect when the socket is down so every poll
+%% from the host application drives recovery.
+%%
+%%   connected              -- socket is currently up
+%%   connecting             -- socket down, no failed retry yet
+%%                             (transient drop or first attempt in flight)
+%%   {disconnected, Reason} -- one or more failed attempts since last
+%%                             success; Reason is the last connect /
+%%                             socket close error (e.g. econnrefused,
+%%                             tcp_closed, {tls_alert, ...}).
 -spec get_connection_state(pid() | atom()) ->
-    connected | connecting | disconnected | {error, term()}.
+    connected
+    | connecting
+    | {disconnected, term()}
+    | {error, term()}.
 get_connection_state(Pid) ->
     try
         gen_server:call(Pid, get_connection_state, 5000)
@@ -116,18 +142,8 @@ init([Servers, Opts]) ->
     },
     {ok, State, {continue, connect}}.
 
-handle_continue(connect, State = #state{sock = undefined,
-                                        servers = Servers,
-                                        opts = Opts,
-                                        reconnect_attempts = N}) ->
-    case get_sock(Servers, undefined, Opts) of
-        error ->
-            %% Leave sock = undefined; subsequent get_status /
-            %% get_routeinfo_by_topic calls will retry the connect.
-            {noreply, State#state{reconnect_attempts = N + 1}};
-        Sock ->
-            {noreply, State#state{sock = Sock, reconnect_attempts = 0}}
-    end;
+handle_continue(connect, State) ->
+    {noreply, do_connect(State)};
 handle_continue(_, State) ->
     {noreply, State}.
 
@@ -136,30 +152,31 @@ handle_call({get_routeinfo_by_topic, Topic}, From, State = #state{opaque_id = Op
                                                                   requests = Reqs,
                                                                   servers = Servers,
                                                                   opts = Opts,
-                                                                  sock_mod = SockSendMod,
-                                                                  reconnect_attempts = N
+                                                                  sock_mod = SockSendMod
                                                                   }) ->
     case get_sock(Servers, Sock, Opts) of
-        error ->
-            log(error, "Servers: ~p down", [Servers]),
-            {noreply, State#state{reconnect_attempts = N + 1}};
-        Sock1 ->
+        {error, Reason} ->
+            log(error, "Servers: ~p down, reason: ~p", [Servers, Reason]),
+            {noreply, record_connect_failure(Reason, State)};
+        {ok, Sock1} ->
             ACLInfo = maps:get(acl_info, Opts, #{}),
             Namespace = maps:get(namespace, Opts, <<>>),
             Package = rocketmq_protocol_frame:get_routeinfo_by_topic(OpaqueId, Namespace, Topic, ACLInfo),
             SockSendMod:send(Sock1, Package),
-            {noreply, next_opaque_id(State#state{requests = maps:put(OpaqueId, From, Reqs),
-                                                 sock = Sock1,
-                                                 reconnect_attempts = 0})}
+            {noreply, next_opaque_id(
+                record_connect_success(
+                    State#state{requests = maps:put(OpaqueId, From, Reqs), sock = Sock1}
+                ))}
     end;
 
 handle_call(get_status, _From, State = #state{sock = undefined,
                                               servers = Servers,
-                                              opts = Opts,
-                                              reconnect_attempts = N}) ->
+                                              opts = Opts}) ->
     case get_sock(Servers, undefined, Opts) of
-        error -> {reply, false, State#state{reconnect_attempts = N + 1}};
-        Sock -> {reply, true, State#state{sock = Sock, reconnect_attempts = 0}}
+        {error, Reason} ->
+            {reply, false, record_connect_failure(Reason, State)};
+        {ok, Sock} ->
+            {reply, true, record_connect_success(State#state{sock = Sock})}
     end;
 handle_call(get_status, _From, State) ->
     {reply, true, State};
@@ -168,16 +185,20 @@ handle_call(get_connection_state, _From, State = #state{sock = undefined,
                                                         reconnect_attempts = 0}) ->
     %% Socket is down but no failed retry yet (either a transient drop
     %% that hasn't been retried, or init hasn't run handle_continue yet).
-    %% Report `connecting' so a brief blip doesn't flip the status.
-    {reply, connecting, State};
-handle_call(get_connection_state, _From, State = #state{sock = undefined}) ->
+    %% Report `connecting' so a brief blip doesn't flip the status; still
+    %% kick off a reconnect so we don't rely on the producer's slower
+    %% route-refresh cadence to recover.
+    {reply, connecting, kick_async_reconnect(State)};
+handle_call(get_connection_state, _From, State = #state{sock = undefined,
+                                                        last_error = LastError}) ->
     %% One or more failed connect attempts since the last success --
     %% treat as a terminal failure until the host application drives
-    %% another attempt (via get_status, or a producer route refresh).
-    %% Callers map this to the `disconnected' resource status so a
-    %% misconfigured connector surfaces correctly rather than appearing
-    %% to be 'still trying'.
-    {reply, disconnected, State};
+    %% another attempt. Callers map this to the `disconnected' resource
+    %% status so a misconfigured connector surfaces correctly rather
+    %% than appearing to be 'still trying'. Keep attempting in the
+    %% background so recovery happens automatically once the broker is
+    %% reachable again.
+    {reply, {disconnected, LastError}, kick_async_reconnect(State)};
 handle_call(get_connection_state, _From, State) ->
     %% sock =/= undefined -- either a gen_tcp port or an ssl socket tuple
     {reply, connected, State};
@@ -195,15 +216,20 @@ handle_info({ssl, Sock, Bin}, #state{sock = Sock} = State) ->
     handle_response(Bin, State);
 
 handle_info({tcp_closed, Sock}, State = #state{sock = Sock}) ->
-    {noreply, State#state{sock = undefined}, hibernate};
+    {noreply, record_socket_drop(tcp_closed, State), hibernate};
 
 handle_info({ssl_closed, Sock}, State = #state{sock = Sock}) ->
-    {noreply, State#state{sock = undefined}, hibernate};
+    {noreply, record_socket_drop(ssl_closed, State), hibernate};
 
 handle_info({ssl_error, Sock, Reason}, State = #state{sock = Sock}) ->
     _ = ssl:close(Sock),
     log(error, "RocketMQ client Received SSL socket error: ~p~n", [Reason]),
-    {noreply, State#state{sock = undefined}, hibernate};
+    {noreply, record_socket_drop({ssl_error, Reason}, State), hibernate};
+
+handle_info(try_reconnect, State = #state{sock = undefined}) ->
+    {noreply, do_connect(State#state{reconnecting = false}), hibernate};
+handle_info(try_reconnect, State) ->
+    {noreply, State#state{reconnecting = false}, hibernate};
 
 handle_info(_Info, State) ->
     log(error, "RocketMQ client Receive unknown message:~p~n", [_Info]),
@@ -243,16 +269,50 @@ tune_buffer(Sock) ->
         = inet:getopts(Sock, [recbuf, sndbuf]),
     inet:setopts(Sock, [{buffer, max(RecBuf, SndBuf)}]).
 
+%% Attempt a connect once, updating state accordingly. The caller
+%% decides whether that was driven by init (handle_continue) or a
+%% kick_async_reconnect (handle_info).
+do_connect(State = #state{sock = undefined,
+                          servers = Servers,
+                          opts = Opts}) ->
+    case get_sock(Servers, undefined, Opts) of
+        {error, Reason} ->
+            record_connect_failure(Reason, State);
+        {ok, Sock} ->
+            record_connect_success(State#state{sock = Sock})
+    end;
+do_connect(State) ->
+    State.
+
+record_connect_success(State) ->
+    State#state{reconnect_attempts = 0, last_error = undefined}.
+
+record_connect_failure(Reason, State = #state{reconnect_attempts = N}) ->
+    State#state{reconnect_attempts = N + 1, last_error = Reason}.
+
+record_socket_drop(Reason, State) ->
+    %% A socket drop is not itself a failed connect attempt, so we
+    %% don't bump reconnect_attempts here. We do remember the reason
+    %% so get_connection_state can surface it if the next reconnect
+    %% also fails.
+    State#state{sock = undefined, last_error = Reason}.
+
+kick_async_reconnect(State = #state{reconnecting = true}) ->
+    State;
+kick_async_reconnect(State) ->
+    self() ! try_reconnect,
+    State#state{reconnecting = true}.
+
 get_sock(Servers, undefined, Opts) ->
     SSLOpts = maps:get(ssl_opts, Opts, undefined),
     ConnectTimeout = maps:get(connect_timeout, Opts, ?CONNECT_TIMEOUT),
-    try_connect(Servers, SSLOpts, ConnectTimeout);
+    try_connect(Servers, SSLOpts, ConnectTimeout, no_error);
 get_sock(_Servers, Sock, _Opts) ->
-    Sock.
+    {ok, Sock}.
 
-try_connect([], _SSLOpts, _ConnectTimeout) ->
-    error;
-try_connect([{Host, Port} | Servers], SSLOpts, ConnectTimeout) ->
+try_connect([], _SSLOpts, _ConnectTimeout, LastError) ->
+    {error, LastError};
+try_connect([{Host, Port} | Servers], SSLOpts, ConnectTimeout, _PrevError) ->
     case gen_tcp:connect(Host, Port, ?TCPOPTIONS, ConnectTimeout) of
         {ok, Sock} ->
             tune_buffer(Sock),
@@ -261,23 +321,25 @@ try_connect([{Host, Port} | Servers], SSLOpts, ConnectTimeout) ->
                 {error, TLSConnectErrorReason} ->
                     log(warning, "Could not establish TLS connection ~p:~p, Reason: ~p",
                         [Host, Port, TLSConnectErrorReason]),
-                    try_connect(Servers, SSLOpts, ConnectTimeout);
-                TLSSock ->
-                    TLSSock
+                    try_connect(Servers, SSLOpts, ConnectTimeout,
+                                {tls_connect_error, {Host, Port, TLSConnectErrorReason}});
+                {ok, TLSSock} ->
+                    {ok, TLSSock}
             end;
         {error, TCPConnectErrorReason} ->
             log(warning, "Could not establish TCP connection ~p:~p, Reason: ~p",
                 [Host, Port, TCPConnectErrorReason]),
-            try_connect(Servers, SSLOpts, ConnectTimeout)
+            try_connect(Servers, SSLOpts, ConnectTimeout,
+                        {tcp_connect_error, {Host, Port, TCPConnectErrorReason}})
     end.
 
 maybe_upgrade_tls(Sock, undefined, _ConnectTimeout) ->
-    Sock;
+    {ok, Sock};
 maybe_upgrade_tls(Sock, SSLOpts, ConnectTimeout) ->
     case ssl:connect(Sock, SSLOpts, ConnectTimeout) of
         {ok, Sock1} ->
             ?tp(rocketmq_client_got_tls_sock, #{}),
-            Sock1;
+            {ok, Sock1};
         Error ->
             Error
     end.

--- a/test/rocketmq_client_SUITE.erl
+++ b/test/rocketmq_client_SUITE.erl
@@ -1,0 +1,265 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Unit-level tests for rocketmq_client state machine. Uses a tiny
+%% gen_tcp listener helper instead of a real RocketMQ broker so the
+%% tests can deterministically exercise connect / drop / reconnect
+%% transitions.
+%%--------------------------------------------------------------------
+
+-module(rocketmq_client_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2]).
+
+-export([t_connect_refused_reports_disconnected_with_reason/1,
+         t_connect_success_reports_connected/1,
+         t_socket_drop_flips_to_connecting_with_reason/1,
+         t_reconnect_driven_by_get_connection_state_poll/1,
+         t_reconnecting_flag_dedups_polls/1,
+         t_unreachable_then_reachable_recovers/1,
+         t_get_status_unchanged_for_backwards_compat/1]).
+
+all() ->
+    [t_connect_refused_reports_disconnected_with_reason,
+     t_connect_success_reports_connected,
+     t_socket_drop_flips_to_connecting_with_reason,
+     t_reconnect_driven_by_get_connection_state_poll,
+     t_reconnecting_flag_dedups_polls,
+     t_unreachable_then_reachable_recovers,
+     t_get_status_unchanged_for_backwards_compat].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) -> ok.
+
+init_per_testcase(TC, Config) ->
+    %% Each case gets a unique registered ClientId so parallel
+    %% start_link calls don't collide via the local name registry.
+    [{client_id, list_to_atom("rocketmq_client_test_" ++ atom_to_list(TC))} | Config].
+
+end_per_testcase(_TC, Config) ->
+    ClientId = ?config(client_id, Config),
+    case whereis(ClientId) of
+        undefined -> ok;
+        Pid -> ok = stop(Pid)
+    end,
+    ok.
+
+%%--------------------------------------------------------------------
+%% Cases
+
+t_connect_refused_reports_disconnected_with_reason(Config) ->
+    %% Pick a free port and never bind to it -> immediate econnrefused.
+    Port = free_port(),
+    {ok, Pid} = start_client(?config(client_id, Config),
+                             [{"127.0.0.1", Port}], #{}),
+    %% handle_continue fires the first attempt synchronously before the
+    %% gen_server starts accepting external calls; it fails immediately
+    %% and bumps reconnect_attempts.
+    ?assertMatch({disconnected, {tcp_connect_error, {_, _, econnrefused}}},
+                 rocketmq_client:get_connection_state(Pid)),
+    ok.
+
+t_connect_success_reports_connected(Config) ->
+    {ok, Listener, Port} = start_listener(),
+    {ok, Pid} = start_client(?config(client_id, Config),
+                             [{"127.0.0.1", Port}], #{}),
+    ok = wait_for(fun() -> rocketmq_client:get_connection_state(Pid) =:= connected end, 2000),
+    ?assertEqual(connected, rocketmq_client:get_connection_state(Pid)),
+    stop_listener(Listener),
+    ok.
+
+t_socket_drop_flips_to_connecting_with_reason(Config) ->
+    {ok, Listener, Port} = start_listener(),
+    {ok, Pid} = start_client(?config(client_id, Config),
+                             [{"127.0.0.1", Port}], #{}),
+    ok = wait_for(fun() -> rocketmq_client:get_connection_state(Pid) =:= connected end, 2000),
+    %% Close the listener and all its accepted sockets to simulate a drop.
+    stop_listener(Listener),
+    ok = wait_for(
+           fun() ->
+                   case rocketmq_client:get_connection_state(Pid) of
+                       connecting -> true;
+                       {disconnected, _} -> true;
+                       _ -> false
+                   end
+           end, 2000),
+    %% After the drop but before the next failed retry, the status is
+    %% `connecting'. After the next retry fails (listener is gone) it
+    %% flips to {disconnected, _}.
+    ok = wait_for(
+           fun() ->
+                   case rocketmq_client:get_connection_state(Pid) of
+                       {disconnected, _} -> true;
+                       _ -> false
+                   end
+           end, 5000),
+    {disconnected, Reason} = rocketmq_client:get_connection_state(Pid),
+    %% Reason is either the original drop (tcp_closed) or the follow-up
+    %% failed reconnect. Either way, a concrete tagged reason rather
+    %% than `undefined'.
+    ?assertMatch(R when R =/= undefined, Reason),
+    ok.
+
+t_reconnect_driven_by_get_connection_state_poll(Config) ->
+    %% Start with no server, client stays disconnected.
+    Port = free_port(),
+    {ok, Pid} = start_client(?config(client_id, Config),
+                             [{"127.0.0.1", Port}], #{}),
+    ?assertMatch({disconnected, _}, rocketmq_client:get_connection_state(Pid)),
+    %% Bring up a listener on that port, then poll a few times to
+    %% confirm get_connection_state drives the reconnect itself (no
+    %% producer traffic required).
+    {ok, Listener} = listen_on(Port),
+    ok = wait_for(fun() ->
+                          _ = rocketmq_client:get_connection_state(Pid),
+                          rocketmq_client:get_connection_state(Pid) =:= connected
+                  end, 3000),
+    ?assertEqual(connected, rocketmq_client:get_connection_state(Pid)),
+    stop_listener(Listener),
+    ok.
+
+t_reconnecting_flag_dedups_polls(Config) ->
+    %% With a dead port, reconnect attempts are slow (TCP connect
+    %% timeout). Fire a burst of get_connection_state calls and assert
+    %% only one `try_reconnect' message is in flight at any moment --
+    %% the `reconnecting' flag must prevent mailbox buildup.
+    Port = free_port(),
+    {ok, Pid} = start_client(?config(client_id, Config),
+                             [{"127.0.0.1", Port}], #{}),
+    _ = rocketmq_client:get_connection_state(Pid),
+    %% Fire 50 polls in quick succession. If dedup wasn't working we'd
+    %% accumulate 50 try_reconnect messages in the mailbox.
+    [rocketmq_client:get_connection_state(Pid) || _ <- lists:seq(1, 50)],
+    {message_queue_len, QLen} = erlang:process_info(Pid, message_queue_len),
+    %% Allow for at most one queued try_reconnect (the in-flight one is
+    %% not counted in message_queue_len since it's mid-handler).
+    ?assert(QLen =< 1, {too_many_pending, QLen}),
+    ok.
+
+t_unreachable_then_reachable_recovers(Config) ->
+    %% End-to-end recovery: unreachable -> reachable -> connected.
+    Port = free_port(),
+    {ok, Pid} = start_client(?config(client_id, Config),
+                             [{"127.0.0.1", Port}], #{}),
+    ok = wait_for(
+           fun() ->
+                   case rocketmq_client:get_connection_state(Pid) of
+                       {disconnected, _} -> true;
+                       _ -> false
+                   end
+           end, 2000),
+    {ok, Listener} = listen_on(Port),
+    %% Polling drives recovery; within ~3s of bringing the listener up,
+    %% the client should flip to connected.
+    ok = wait_for(
+           fun() ->
+                   _ = rocketmq_client:get_connection_state(Pid),
+                   rocketmq_client:get_connection_state(Pid) =:= connected
+           end, 3000),
+    stop_listener(Listener),
+    ok.
+
+t_get_status_unchanged_for_backwards_compat(Config) ->
+    {ok, Listener, Port} = start_listener(),
+    {ok, Pid} = start_client(?config(client_id, Config),
+                             [{"127.0.0.1", Port}], #{}),
+    ok = wait_for(fun() -> rocketmq_client:get_status(Pid) =:= true end, 2000),
+    ?assertEqual(true, rocketmq_client:get_status(Pid)),
+    stop_listener(Listener),
+    %% After the server goes away and sock drops, get_status should
+    %% attempt an inline reconnect and return false (preserving the
+    %% pre-v0.7.0 return shape).
+    ok = wait_for(fun() -> rocketmq_client:get_status(Pid) =:= false end, 5000),
+    ok.
+
+%%--------------------------------------------------------------------
+%% helpers
+
+start_client(ClientId, Servers, ExtraOpts) ->
+    Opts = maps:merge(#{connect_timeout => 1000}, ExtraOpts),
+    rocketmq_client:start_link(ClientId, Servers, Opts).
+
+stop(Pid) when is_pid(Pid) ->
+    %% Unlink first so the test process isn't taken down by the
+    %% start_link relationship when we terminate the client.
+    unlink(Pid),
+    try gen_server:stop(Pid, shutdown, 2000) of
+        ok -> ok
+    catch
+        exit:noproc -> ok;
+        exit:{noproc, _} -> ok
+    end.
+
+free_port() ->
+    {ok, L} = gen_tcp:listen(0, [binary, {active, false}, {reuseaddr, true}]),
+    {ok, Port} = inet:port(L),
+    ok = gen_tcp:close(L),
+    Port.
+
+start_listener() ->
+    Port = free_port(),
+    {ok, L} = listen_on(Port),
+    {ok, L, Port}.
+
+%% Returns an opaque listener handle that tracks both the listen socket
+%% and every accepted socket, so stop_listener/1 can close them all
+%% and deterministically drop whatever the client connected through.
+-record(listener, {acceptor, ctrl}).
+
+listen_on(Port) ->
+    {ok, LSock} = gen_tcp:listen(Port, [binary, {active, false}, {reuseaddr, true}]),
+    Parent = self(),
+    Ctrl = spawn_link(fun() -> listener_ctrl_loop(LSock, Parent, []) end),
+    {ok, #listener{acceptor = LSock, ctrl = Ctrl}}.
+
+listener_ctrl_loop(LSock, Parent, Accepted) ->
+    receive
+        stop ->
+            catch gen_tcp:close(LSock),
+            [catch gen_tcp:close(S) || S <- Accepted],
+            ok
+    after 0 ->
+        case gen_tcp:accept(LSock, 100) of
+            {ok, Sock} ->
+                gen_tcp:controlling_process(Sock, self()),
+                listener_ctrl_loop(LSock, Parent, [Sock | Accepted]);
+            {error, timeout} ->
+                listener_ctrl_loop(LSock, Parent, Accepted);
+            {error, closed} ->
+                ok;
+            {error, _} ->
+                ok
+        end
+    end.
+
+stop_listener(#listener{ctrl = Ctrl}) ->
+    Ref = erlang:monitor(process, Ctrl),
+    Ctrl ! stop,
+    receive
+        {'DOWN', Ref, process, Ctrl, _} -> ok
+    after 2000 ->
+        erlang:demonitor(Ref, [flush]),
+        ok
+    end.
+
+wait_for(Pred, Timeout) ->
+    Deadline = erlang:monotonic_time(millisecond) + Timeout,
+    wait_loop(Pred, Deadline).
+
+wait_loop(Pred, Deadline) ->
+    case Pred() of
+        true -> ok;
+        false ->
+            case erlang:monotonic_time(millisecond) of
+                T when T > Deadline -> {error, timeout};
+                _ ->
+                    timer:sleep(50),
+                    wait_loop(Pred, Deadline)
+            end
+    end.


### PR DESCRIPTION
## Summary

Two connected changes driven by [emqx/emqx#17113](https://github.com/emqx/emqx/pull/17113) CT findings and [a review comment from Thales](https://github.com/emqx/emqx/pull/17112#discussion_r2143830000) asking for richer status info:

1. **Track last connect / socket failure reason in state** and surface it from `get_connection_state/1` as `{disconnected, Reason}`. The host application can map this to a specific status message (e.g. \"TLS alert: bad certificate\" / \"TCP connect error: econnrefused\") instead of a bare `disconnected` atom.

2. **Drive an async reconnect from every `get_connection_state` poll** when the socket is down, guarded by a `reconnecting` flag so retries don't pile up. After the non-blocking-init PR, the only thing driving reconnects was the producer's 3 s route-refresh (itself blocked for up to 15 s on the stale socket), which made the `t_on_get_status` recovery case in EMQX CT flap right at the edge of its 20 s retry budget.

## API shape

```erlang
get_connection_state(Pid) ->
    connected
  | connecting
  | {disconnected, Reason}
  | {error, term()}.     %% for timeouts / client-down on the call itself
```

`connected` / `connecting` are bare atoms as before. Only `disconnected` carries a payload, to keep match arms in callers minimal.

`Reason` is the most recent connect or socket failure captured in state:
- `{tcp_connect_error, {Host, Port, Reason}}`
- `{tls_connect_error, {Host, Port, Reason}}`
- `tcp_closed` / `ssl_closed`
- `{ssl_error, Reason}`

`get_status/1` is unchanged.

## Test plan

- [x] Module compiles clean on OTP 27.
- [ ] Re-run the EMQX rocketmq CT: both `t_on_get_status` (recovery) and the v5 `t_setup_via_config_ssl_host_bad_ssl_opts` should stabilise.