### PR TITLE
Fix producer batch request leak

### DIFF
--- a/src/rocketmq.app.src
+++ b/src/rocketmq.app.src
@@ -1,6 +1,6 @@
 {application,rocketmq,
              [{description,"A Erlang client library for Apache RocketMQ"},
-              {vsn,"0.6.0"},
+              {vsn,"0.7.2"},
               {modules,[]},
               {registered,[rocketmq_sup]},
               {applications,[kernel,stdlib,jsone,ssl]},

--- a/src/rocketmq.appup.src
+++ b/src/rocketmq.appup.src
@@ -1,10 +1,10 @@
-{"0.5.3",
+{"0.7.2",
   [
-    {<<"0\\.5\\.[0-2]">>,[{restart_application,rocketmq}]},
-    {<<".*">>, []}
+    {"0.7.1", [{load_module, rocketmq_producer, brutal_purge, soft_purge, []}]},
+    {<<".*">>, [{restart_application, rocketmq}]}
   ],
   [
-    {<<"0\\.5\\.[0-2]">>,[{restart_application,rocketmq}]},
-    {<<".*">>, []}
+    {"0.7.1", [{load_module, rocketmq_producer, brutal_purge, soft_purge, []}]},
+    {<<".*">>, [{restart_application, rocketmq}]}
   ]
 }.

--- a/src/rocketmq_producer.erl
+++ b/src/rocketmq_producer.erl
@@ -315,7 +315,7 @@ do_response(Header, Reqs, Callback, Topic) ->
                             end
                     end
             end,
-            Reqs;
+            maps:remove(Opaque, Reqs);
         undefined ->
             %% ignore heart beat response
             Reqs;

--- a/test/rocketmq_producer_tests.erl
+++ b/test/rocketmq_producer_tests.erl
@@ -1,0 +1,56 @@
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(rocketmq_producer_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-record(state, {
+    producer_group,
+    topic,
+    server,
+    sock,
+    client_id = undefined,
+    sock_mod = gen_tcp,
+    queue_id,
+    opaque_id = 1,
+    opts = [],
+    ssl_opts = undefined,
+    callback,
+    batch_size = 0,
+    requests = #{},
+    last_bin = <<>>,
+    producer_opts
+}).
+
+completed_batch_response_removes_request_test() ->
+    Opaque = 42,
+    OtherOpaque = 999,
+    State0 = #state{
+        requests = #{Opaque => {batch_len, 3}, OtherOpaque => pending},
+        callback = undefined,
+        topic = <<"topic">>
+    },
+    {keep_state, State} = rocketmq_producer:connected(info, response(Opaque), State0),
+    ?assertEqual(#{OtherOpaque => pending}, State#state.requests).
+
+response(Opaque) ->
+    HeaderData = jsone:encode([
+        {<<"code">>, 0},
+        {<<"opaque">>, Opaque},
+        {<<"extFields">>, []}
+    ]),
+    HeaderLen = byte_size(HeaderData),
+    Len = 4 + HeaderLen,
+    <<Len:32, HeaderLen:32, HeaderData/binary>>.


### PR DESCRIPTION
Port 83afc0ccf3b4b7d59f9d0a4ea452ec7c213154fa
## Summary

This PR fixes a RocketMQ producer memory leak in the async/batched response path.

When an async send is tracked as `{batch_len, Len}`, `do_response/4` invokes the optional callback but leaves the completed opaque entry in the producer `requests` map. Over time, successful async sends keep accumulating in producer state.

The fix removes the completed opaque entry from `requests`, matching the synchronous reply path. The regression test lives under `test/` and exercises the producer state callback without requiring a real RocketMQ broker.

It also bumps the application version to `0.7.2` and updates `rocketmq.appup.src` so the next tag can be cut after merge.

## Validation

- `make compile`
- `make xref`
- `rebar3 as test eunit --module=rocketmq_producer_tests`
- `git diff --check`
- `erl -noshell -eval 'case file:consult("src/rocketmq.appup.src") of {ok, [_]} -> halt(0); Error -> io:format("~p~n", [Error]), halt(1) end.'`

Note: a local `make eunit` run without a RocketMQ broker still fails in the existing integration-style `test.erl` path with `127.0.0.1:9876 econnrefused`; the new regression test is broker-independent.
